### PR TITLE
fix: add dm_pix to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scikit-video
 optax
 chex
 jax
+dm-pix
 scikit-learn
 numpy==1.21.6
 numba==0.55


### PR DESCRIPTION
dm_pix is needed to do training on the docker image.

Closes #2 