### PR TITLE
fix: replace deprecated jax.numpy.trapz

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
 
       - name: apt-get

--- a/celegans/simulation.py
+++ b/celegans/simulation.py
@@ -6,6 +6,7 @@ import random
 
 import jax
 import jax.numpy as jnp
+from jax.scipy.integrate import trapezoid
 
 
 def _theta(t, s, params):
@@ -123,9 +124,9 @@ def solve(t, u, X, ds, alpha):
     fx = Ut * tx[jnp.newaxis] + alpha * Un * nx[jnp.newaxis]
     fy = Ut * ty[jnp.newaxis] + alpha * Un * ny[jnp.newaxis]
 
-    Fx = jnp.trapz(fx, dx=ds)
-    Fy = jnp.trapz(fy, dx=ds)
-    Tau = jnp.trapz(x * fy - y * fx, dx=ds)
+    Fx = trapezoid(fx, dx=ds)
+    Fy = trapezoid(fy, dx=ds)
+    Tau = trapezoid(x * fy - y * fx, dx=ds)
 
     b = -jnp.array([Fx[0], Fy[0], Tau[0]])
     A = jnp.array([Fx[1:], Fy[1:], Tau[1:]])

--- a/examples/detect.py
+++ b/examples/detect.py
@@ -2,6 +2,12 @@ from absl import app, flags
 import deeptangle as dt
 import matplotlib.pyplot as plt
 from skimage.exposure import equalize_adapthist
+import numpy
+
+# scikit-video uses deprecated numpy.float, numpy.int
+# hacky fix: https://github.com/scikit-video/scikit-video/issues/154
+numpy.float = numpy.float64
+numpy.int = numpy.int_
 import skvideo.io
 
 

--- a/examples/track.py
+++ b/examples/track.py
@@ -9,6 +9,12 @@ from matplotlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 from skimage.exposure import equalize_adapthist
+
+# scikit-video uses deprecated numpy.float, numpy.int
+# hacky fix: https://github.com/scikit-video/scikit-video/issues/154
+import numpy
+numpy.float = numpy.float64
+numpy.int = numpy.int_
 import skvideo.io
 
 import deeptangle as dt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,12 @@ scikit-image
 scikit-video
 optax
 chex
-jax
+jax>=0.4.16
+jaxlib>=0.4.20
 dm-pix
 scikit-learn
-numpy==1.21.6
-numba==0.55
+numpy>=1.21.6
+numba>=0.55
 matplotlib
-https://github.com/alonfnt/dm-haiku/archive/refs/heads/avg_pool_perf.zip
+dm-haiku
 trackpy


### PR DESCRIPTION
Apparently in the 0.4.16 JAX release, there were several deprecations following NEP52
(https://numpy.org/neps/nep-0052-python-api-cleanup.html) One of those was jax.numpy.trapz. Instead we are meant to use jax.scipy.integrate.trapozoid.

The C. Elegans code used trapz so it is not running on the current version.